### PR TITLE
consider that the function "string-equal" does NOT ignore leading and trailing whitespace

### DIFF
--- a/Privacy Policy Stack/Patient Specific via Policy Manager/EPD Setup/202-patient-access-level.xml
+++ b/Privacy Policy Stack/Patient Specific via Policy Manager/EPD Setup/202-patient-access-level.xml
@@ -6,6 +6,7 @@ Implementation material for Privacy Policy Format
 History:
 2018-07-03: First edition
 2021-07-06: Second edition
+2021-12-13: Third edition
 
 ********************************************************
 -->
@@ -32,9 +33,7 @@ History:
 					AttributeId="urn:oasis:names:tc:xacml:2.0:subject:role" />
 				</SubjectMatch>
 				<SubjectMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-					<AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">
-						urn:gs1:gln
-					</AttributeValue>
+					<AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:gs1:gln</AttributeValue>
 					<SubjectAttributeDesignator
 						AttributeId="urn:oasis:names:tc:xacml:1.0:subject:subject-id-qualifier"
 					DataType="http://www.w3.org/2001/XMLSchema#string" />

--- a/Privacy Policy Stack/Patient Specific via Policy Manager/EPD Setup/203-patient-provide-level.xml
+++ b/Privacy Policy Stack/Patient Specific via Policy Manager/EPD Setup/203-patient-provide-level.xml
@@ -5,6 +5,7 @@ Implementation material for Privacy Policy Format
 
 History:
 2018-07-03: second edition
+2021-12-13: Third edition
 
 ********************************************************
 -->
@@ -31,9 +32,7 @@ History:
 					AttributeId="urn:oasis:names:tc:xacml:2.0:subject:role" />
 				</SubjectMatch>
 				<SubjectMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-					<AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">
-						urn:gs1:gln
-					</AttributeValue>
+					<AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:gs1:gln</AttributeValue>
 					<SubjectAttributeDesignator
 						AttributeId="urn:oasis:names:tc:xacml:1.0:subject:subject-id-qualifier"
 					DataType="http://www.w3.org/2001/XMLSchema#string" />
@@ -57,9 +56,7 @@ History:
 					AttributeId="urn:oasis:names:tc:xacml:2.0:subject:role" />
 				</SubjectMatch>
 				<SubjectMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-					<AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">
-						urn:gs1:gln
-					</AttributeValue>
+					<AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:gs1:gln</AttributeValue>
 					<SubjectAttributeDesignator
 						AttributeId="urn:oasis:names:tc:xacml:1.0:subject:subject-id-qualifier"
 					DataType="http://www.w3.org/2001/XMLSchema#string" />

--- a/epr-patient-specific-policies.sch
+++ b/epr-patient-specific-policies.sch
@@ -8,6 +8,7 @@ History:
 07-Jun-2021: Initial version (Dmytro Rud, Swiss Post)
 07-Jul-2021: Fix of ResourceMatch validation (Dmytro Rud, Swiss Post)
 20-Jul-2021: Check that policy set IDs are UUIDs in URN format (Dmytro Rud, Swiss Post)
+01-Dec-2021: Do not trim whitespace in attribute values (Dmytro Rud, Swiss Post)
 -->
 <sch:schema queryBinding="xslt2"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
@@ -23,7 +24,7 @@ History:
     <sch:ns prefix="xsi"    uri="http://www.w3.org/2001/XMLSchema-instance"/>
 
     <!-- if this parameter is set to true, then the validation will fail if the to-date in EnvironmentMatch is less than the current date -->
-    <sch:let name="need-check-current-date" value="fn:true()"/>
+    <sch:let name="need-check-current-date" value="fn:false()"/>
 
     <sch:pattern id="pattern1">
 
@@ -164,25 +165,25 @@ History:
     <!-- Returns true iff the given string represents an OID in URN format -->
     <xsl:function name="val:is-oid-urn" as="xs:boolean">
         <xsl:param name="value" as="xs:string"/>
-        <xsl:sequence select="fn:matches(fn:normalize-space($value), '^urn:oid:([0-2])((\.0)|(\.[1-9][0-9]*))*$', 'i')"/>
+        <xsl:sequence select="fn:matches($value, '^urn:oid:([0-2])((\.0)|(\.[1-9][0-9]*))*$', 'i')"/>
     </xsl:function>
 
     <!-- Returns true iff the given string represents an UUID in URN format -->
     <xsl:function name="val:is-uuid-urn" as="xs:boolean">
         <xsl:param name="value" as="xs:string"/>
-        <xsl:sequence select="fn:matches(fn:normalize-space($value), '^urn:uuid:[0-9a-f]{8}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{12}$', 'i')"/>
+        <xsl:sequence select="fn:matches($value, '^urn:uuid:[0-9a-f]{8}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{12}$', 'i')"/>
     </xsl:function>
 
     <!-- Returns true iff the given string represents an EPR-SPID -->
     <xsl:function name="val:is-epr-spid" as="xs:boolean">
         <xsl:param name="value" as="xs:string"/>
-        <xsl:sequence select="fn:matches(fn:normalize-space($value), '^\d{18}$')"/>
+        <xsl:sequence select="fn:matches($value, '^\d{18}$')"/>
     </xsl:function>
 
     <!-- Returns true iff the given string represents a GLN -->
     <xsl:function name="val:is-gln" as="xs:boolean">
         <xsl:param name="value" as="xs:string"/>
-        <xsl:sequence select="fn:matches(fn:normalize-space($value), '^\d{13}$')"/>
+        <xsl:sequence select="fn:matches($value, '^\d{13}$')"/>
     </xsl:function>
 
     <!-- Returns true iff the given string represents an ID of a REP -->
@@ -194,7 +195,7 @@ History:
     <!-- Returns the attribute value of the given SubjectMatch element, as string -->
     <xsl:function name="val:attribute-value-text" as="xs:string">
         <xsl:param name="element"/>
-        <xsl:sequence select="fn:normalize-space($element/xacml:AttributeValue/text())"/>
+        <xsl:sequence select="$element/xacml:AttributeValue/text()"/>
     </xsl:function>
 
     <!-- Returns true iff the given element is a designator with the given attribute ID and data type -->


### PR DESCRIPTION
Hallo Daniel
Hallo Martin

Es hat sich festgestellt dass die XACML-Funktion "string-equal" Leerzeichen aller Art (d.h. auch Zeilenumbrüche usw.) am Anfang und am Ende jedes Werts NICHT ignoriert.  In der Java-Bibliothek HERAS AF, welche für die Auswertung von XACML-Policies genutzt wird, war diese Funktion bis vor Kurzem verkehrt implementiert, sodass Leerzeichen fälschlicherweise keine Rolle gespielt haben.  Jetzt ist das gefixt.

In diesem Pull Request habe ich das Schematron entsprechend angepasst, und auch Templates, wo die Attributen-Werte mit Leerzeichen umrahmt waren.

Vielen Dank und beste Grüsse
Dmytro